### PR TITLE
CASSANDRA-15807 Support running diff on multiple keyspaces

### DIFF
--- a/api-server/src/main/java/org/apache/cassandra/diff/api/services/DBService.java
+++ b/api-server/src/main/java/org/apache/cassandra/diff/api/services/DBService.java
@@ -80,8 +80,7 @@ public class DBService implements Closeable {
             "   job_id," +
             "   job_start_time," +
             "   buckets," +
-            "   keyspace_name, " +
-            "   table_names, " +
+            "   keyspace_table_names, " +
             "   source_cluster_name," +
             "   source_cluster_desc," +
             "   target_cluster_name," +
@@ -92,7 +91,7 @@ public class DBService implements Closeable {
         jobResultStatement = session.prepare(String.format(
             " SELECT " +
             "   job_id," +
-            "   table_name, " +
+            "   keyspace_table_name, " +
             "   matched_partitions," +
             "   mismatched_partitions,"   +
             "   matched_rows,"   +
@@ -102,12 +101,12 @@ public class DBService implements Closeable {
             "   partitions_only_in_target,"   +
             "   skipped_partitions"   +
             " FROM %s.job_results" +
-            " WHERE job_id = ? AND table_name = ?", diffKeyspace));
+            " WHERE job_id = ? AND keyspace_table_name = ?", diffKeyspace));
         jobStatusStatement = session.prepare(String.format(
             " SELECT " +
             "   job_id,"   +
             "   bucket,"   +
-            "   table_name,"   +
+            "   keyspace_table_name,"   +
             "   completed "   +
             " FROM %s.job_status" +
             " WHERE job_id = ? AND bucket = ?", diffKeyspace));
@@ -115,7 +114,7 @@ public class DBService implements Closeable {
             " SELECT " +
             "   job_id," +
             "   bucket," +
-            "   table_name," +
+            "   keyspace_table_name," +
             "   mismatching_token," +
             "   mismatch_type" +
             " FROM %s.mismatches" +
@@ -123,14 +122,14 @@ public class DBService implements Closeable {
         jobErrorSummaryStatement = session.prepare(String.format(
             " SELECT " +
             "   count(start_token) AS error_count," +
-            "   table_name" +
+            "   keyspace_table_name" +
             " FROM %s.task_errors" +
             " WHERE job_id = ? AND bucket = ?",
             diffKeyspace));
         jobErrorRangesStatement = session.prepare(String.format(
             " SELECT " +
             "   bucket,"   +
-            "   table_name,"   +
+            "   keyspace_table_name,"   +
             "   start_token,"   +
             "   end_token"   +
             " FROM %s.task_errors" +
@@ -138,10 +137,10 @@ public class DBService implements Closeable {
             diffKeyspace));
         jobErrorDetailStatement = session.prepare(String.format(
             " SELECT " +
-            "   table_name,"   +
+            "   keyspace_table_name,"   +
             "   error_token"   +
             " FROM %s.partition_errors" +
-            " WHERE job_id = ? AND bucket = ? AND table_name = ? AND start_token = ? AND end_token = ?", diffKeyspace));
+            " WHERE job_id = ? AND bucket = ? AND keyspace_table_name = ? AND start_token = ? AND end_token = ?", diffKeyspace));
         jobsStartDateStatement = session.prepare(String.format(
             " SELECT " +
             "   job_id" +
@@ -190,8 +189,8 @@ public class DBService implements Closeable {
 
     public Collection<JobResult> fetchJobResults(UUID jobId) {
         JobSummary summary = fetchJobSummary(jobId);
-        List<ResultSetFuture> futures = Lists.newArrayListWithCapacity(summary.tables.size());
-        for (String table : summary.tables)
+        List<ResultSetFuture> futures = Lists.newArrayListWithCapacity(summary.keyspaceTables.size());
+        for (String table : summary.keyspaceTables)
             futures.add(session.executeAsync(jobResultStatement.bind(jobId, table)));
 
         SortedSet<JobResult> results = Sets.newTreeSet();
@@ -206,8 +205,8 @@ public class DBService implements Closeable {
         for (int i = 0; i < summary.buckets; i++)
             futures.add(session.executeAsync(jobStatusStatement.bind(jobId, i)));
 
-        Map<String, Long> completedByTable = Maps.newHashMapWithExpectedSize(summary.tables.size());
-        processFutures(futures, row -> completedByTable.merge(row.getString("table_name"),
+        Map<String, Long> completedByTable = Maps.newHashMapWithExpectedSize(summary.keyspaceTables.size());
+        processFutures(futures, row -> completedByTable.merge(row.getString("keyspace_table_name"),
                                                               row.getLong("completed"),
                                                               Long::sum));
         return new JobStatus(jobId, completedByTable);
@@ -220,8 +219,8 @@ public class DBService implements Closeable {
         for (int i = 0; i < summary.buckets; i++)
             futures.add(session.executeAsync(jobMismatchesStatement.bind(jobId, i)));
 
-        Map<String, List<Mismatch>> mismatchesByTable = Maps.newHashMapWithExpectedSize(summary.tables.size());
-        processFutures(futures, row -> mismatchesByTable.merge(row.getString("table_name"),
+        Map<String, List<Mismatch>> mismatchesByTable = Maps.newHashMapWithExpectedSize(summary.keyspaceTables.size());
+        processFutures(futures, row -> mismatchesByTable.merge(row.getString("keyspace_table_name"),
                                                                Lists.newArrayList(new Mismatch(row.getString("mismatching_token"),
                                                                                                row.getString("mismatch_type"))),
                                                                (l1, l2) -> { l1.addAll(l2); return l1;}));
@@ -235,11 +234,11 @@ public class DBService implements Closeable {
         for (int i = 0; i < summary.buckets; i++)
             futures.add(session.executeAsync(jobErrorSummaryStatement.bind(jobId, i)));
 
-        Map<String, Long> errorCountByTable = Maps.newHashMapWithExpectedSize(summary.tables.size());
+        Map<String, Long> errorCountByTable = Maps.newHashMapWithExpectedSize(summary.keyspaceTables.size());
         processFutures(futures, row -> {
-            String table = row.getString("table_name");
+            String table = row.getString("keyspace_table_name");
             if (null != table) {
-                errorCountByTable.merge(row.getString("table_name"),
+                errorCountByTable.merge(row.getString("keyspace_table_name"),
                                         row.getLong("error_count"),
                                         Long::sum);
             }
@@ -254,8 +253,8 @@ public class DBService implements Closeable {
         for (int i = 0; i < summary.buckets; i++)
             futures.add(session.executeAsync(jobErrorRangesStatement.bind(jobId, i)));
 
-        Map<String, List<Range>> errorRangesByTable = Maps.newHashMapWithExpectedSize(summary.tables.size());
-        processFutures(futures, row -> errorRangesByTable.merge(row.getString("table_name"),
+        Map<String, List<Range>> errorRangesByTable = Maps.newHashMapWithExpectedSize(summary.keyspaceTables.size());
+        processFutures(futures, row -> errorRangesByTable.merge(row.getString("keyspace_table_name"),
                                                                 Lists.newArrayList(new Range(row.getString("start_token"),
                                                                                              row.getString("end_token"))),
                                                                 (l1, l2) -> { l1.addAll(l2); return l1;}));
@@ -273,13 +272,13 @@ public class DBService implements Closeable {
         processFutures(rangeFutures,
                        row -> session.executeAsync(jobErrorDetailStatement.bind(jobId,
                                                                                 row.getInt("bucket"),
-                                                                                row.getString("table_name"),
+                                                                                row.getString("keyspace_table_name"),
                                                                                 row.getString("start_token"),
                                                                                 row.getString("end_token"))),
                        errorFutures::add);
-        Map<String, List<String>> errorsByTable = Maps.newHashMapWithExpectedSize(summary.tables.size());
+        Map<String, List<String>> errorsByTable = Maps.newHashMapWithExpectedSize(summary.keyspaceTables.size());
         processFutures(errorFutures,
-                       row -> errorsByTable.merge(row.getString("table_name"),
+                       row -> errorsByTable.merge(row.getString("keyspace_table_name"),
                                                   Lists.newArrayList(row.getString("error_token")),
                                                   (l1, l2) -> { l1.addAll(l2); return l1;}));
         return new JobErrorDetail(jobId, errorsByTable);
@@ -472,7 +471,7 @@ public class DBService implements Closeable {
 
         static JobResult fromRow(Row row) {
             return new JobResult(row.getUUID("job_id"),
-                                 row.getString("table_name"),
+                                 row.getString("keyspace_table_name"),
                                  row.getLong("matched_partitions"),
                                  row.getLong("mismatched_partitions"),
                                  row.getLong("matched_rows"),
@@ -494,8 +493,7 @@ public class DBService implements Closeable {
 
         final UUID jobId;
         final int buckets;
-        final String keyspace;
-        final List<String> tables;
+        final List<String> keyspaceTables;
         final String sourceClusterName;
         final String sourceClusterDesc;
         final String targetClusterName;
@@ -509,8 +507,7 @@ public class DBService implements Closeable {
         private JobSummary(UUID jobId,
                            DateTime startTime,
                            int buckets,
-                           String keyspace,
-                           List<String> tables,
+                           List<String> keyspaceTables,
                            String sourceClusterName,
                            String sourceClusterDesc,
                            String targetClusterName,
@@ -521,8 +518,7 @@ public class DBService implements Closeable {
             this.startTime = startTime;
             this.start = startTime.toString();
             this.buckets = buckets;
-            this.keyspace = keyspace;
-            this.tables = tables;
+            this.keyspaceTables = keyspaceTables;
             this.sourceClusterName = sourceClusterName;
             this.sourceClusterDesc = sourceClusterDesc;
             this.targetClusterName = targetClusterName;
@@ -534,8 +530,7 @@ public class DBService implements Closeable {
             return new JobSummary(row.getUUID("job_id"),
                                   new DateTime(UUIDs.unixTimestamp(row.getUUID("job_start_time")), DateTimeZone.UTC),
                                   row.getInt("buckets"),
-                                  row.getString("keyspace_name"),
-                                  row.getList("table_names", String.class),
+                                  row.getList("keyspace_table_names", String.class),
                                   row.getString("source_cluster_name"),
                                   row.getString("source_cluster_desc"),
                                   row.getString("target_cluster_name"),

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -49,6 +49,13 @@
             <artifactId>cassandra-driver-core</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/common/src/main/java/org/apache/cassandra/diff/JobConfiguration.java
+++ b/common/src/main/java/org/apache/cassandra/diff/JobConfiguration.java
@@ -26,9 +26,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface JobConfiguration extends Serializable {
-    String keyspace();
-
-    List<String> tables();
+    List<KeyspaceTablePair> keyspaceTables();
 
     int splits();
 

--- a/common/src/main/java/org/apache/cassandra/diff/KeyspaceTablePair.java
+++ b/common/src/main/java/org/apache/cassandra/diff/KeyspaceTablePair.java
@@ -1,0 +1,61 @@
+package org.apache.cassandra.diff;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import com.google.common.base.MoreObjects;
+
+import com.datastax.driver.core.TableMetadata;
+
+public final class KeyspaceTablePair implements Serializable {
+    public final String keyspace;
+    public final String table;
+
+    public static KeyspaceTablePair from(TableMetadata tableMetadata) {
+        return new KeyspaceTablePair(tableMetadata.getKeyspace().getName(), tableMetadata.getName());
+    }
+
+    // Used by Yaml loader
+    public KeyspaceTablePair(String input) {
+        String[] parts = input.trim().split("\\.");
+        assert parts.length == 2 : "Invalid keyspace table pair format";
+        assert parts[0].length() > 0;
+        assert parts[1].length() > 0;
+
+        this.keyspace = parts[0];
+        this.table = parts[1];
+    }
+
+    public KeyspaceTablePair(String keyspace, String table) {
+        this.keyspace = keyspace;
+        this.table = table;
+    }
+
+    public String toCqlValueString() {
+        return String.format("%s.%s", keyspace, table);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("keyspace", keyspace)
+                          .add("table", table)
+                          .toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(keyspace, table);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null || getClass() != obj.getClass())
+            return false;
+        KeyspaceTablePair that = (KeyspaceTablePair) obj;
+        return Objects.equals(keyspace, that.keyspace)
+               && Objects.equals(table, that.table);
+    }
+}

--- a/common/src/main/java/org/apache/cassandra/diff/YamlJobConfiguration.java
+++ b/common/src/main/java/org/apache/cassandra/diff/YamlJobConfiguration.java
@@ -34,8 +34,7 @@ import org.yaml.snakeyaml.constructor.CustomClassLoaderConstructor;
 
 public class YamlJobConfiguration implements JobConfiguration {
     public int splits = 10000;
-    public String keyspace;
-    public List<String> tables;
+    public List<KeyspaceTablePair> keyspace_tables;
     public int buckets = 100;
     public int rate_limit = 10000;
     public String job_id = null;
@@ -59,12 +58,8 @@ public class YamlJobConfiguration implements JobConfiguration {
         }
     }
 
-    public String keyspace() {
-        return keyspace;
-    }
-
-    public List<String> tables() {
-        return tables;
+    public List<KeyspaceTablePair> keyspaceTables() {
+        return keyspace_tables;
     }
 
     public int splits() {
@@ -127,8 +122,7 @@ public class YamlJobConfiguration implements JobConfiguration {
     public String toString() {
         return "YamlJobConfiguration{" +
                "splits=" + splits +
-               ", keyspace='" + keyspace + '\'' +
-               ", tables=" + tables +
+               ", keyspace_tables=" + keyspace_tables +
                ", buckets=" + buckets +
                ", rate_limit=" + rate_limit +
                ", job_id='" + job_id + '\'' +

--- a/common/src/test/java/org/apache/cassandra/diff/YamlJobConfigurationTest.java
+++ b/common/src/test/java/org/apache/cassandra/diff/YamlJobConfigurationTest.java
@@ -1,0 +1,16 @@
+package org.apache.cassandra.diff;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class YamlJobConfigurationTest {
+    @Test
+    public void testLoadYaml() {
+        JobConfiguration jobConfiguration = YamlJobConfiguration.load("src/test/resources/testconfig.yaml");
+        Assert.assertEquals(3, jobConfiguration.keyspaceTables().size());
+        jobConfiguration.keyspaceTables().forEach(kt -> {
+            Assert.assertTrue("Keyspace segment is not loaded correctly", kt.keyspace.contains("ks"));
+            Assert.assertTrue("Table segment is not loaded correctly", kt.table.contains("tb"));
+        });
+    }
+}

--- a/common/src/test/resources/testconfig.yaml
+++ b/common/src/test/resources/testconfig.yaml
@@ -1,6 +1,8 @@
 # List of keyspace.tables to diff
 keyspace_tables:
-  - keyspace1.standard1
+  - ks1.tb1
+  - ks1.tb2
+  - ks2.tb3
 
 # This is how many parts we split the full token range in.
 # Each of these splits is then compared between the clusters

--- a/spark-job/localconfig-multi-keyspaces.yaml
+++ b/spark-job/localconfig-multi-keyspaces.yaml
@@ -1,6 +1,7 @@
 # List of keyspace.tables to diff
 keyspace_tables:
   - keyspace1.standard1
+  - keyspace2.standard1
 
 # This is how many parts we split the full token range in.
 # Each of these splits is then compared between the clusters

--- a/spark-job/src/main/java/org/apache/cassandra/diff/ComparisonExecutor.java
+++ b/spark-job/src/main/java/org/apache/cassandra/diff/ComparisonExecutor.java
@@ -19,11 +19,19 @@
 
 package org.apache.cassandra.diff;
 
-import java.util.concurrent.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Phaser;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.Semaphore;
 import java.util.function.Consumer;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.util.concurrent.*;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;

--- a/spark-job/src/main/java/org/apache/cassandra/diff/DiffCluster.java
+++ b/spark-job/src/main/java/org/apache/cassandra/diff/DiffCluster.java
@@ -20,22 +20,48 @@
 package org.apache.cassandra.diff;
 
 import java.math.BigInteger;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.google.common.collect.AbstractIterator;
-import com.google.common.util.concurrent.*;
-
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.RateLimiter;
+import com.google.common.util.concurrent.Uninterruptibles;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.datastax.driver.core.*;
-import com.datastax.driver.core.querybuilder.*;
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.ClusteringOrder;
+import com.datastax.driver.core.ColumnMetadata;
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.ResultSetFuture;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.TableMetadata;
+import com.datastax.driver.core.querybuilder.BuiltStatement;
+import com.datastax.driver.core.querybuilder.Ordering;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+import com.datastax.driver.core.querybuilder.Select;
 import org.jetbrains.annotations.NotNull;
 
+import static com.datastax.driver.core.querybuilder.QueryBuilder.asc;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.desc;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.gt;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.lte;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.token;
 import static org.apache.cassandra.diff.DiffContext.cqlizedString;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
 
 public class DiffCluster implements AutoCloseable
 {

--- a/spark-job/src/main/java/org/apache/cassandra/diff/DiffJob.java
+++ b/spark-job/src/main/java/org/apache/cassandra/diff/DiffJob.java
@@ -21,14 +21,17 @@ package org.apache.cassandra.diff;
 
 import java.io.Serializable;
 import java.math.BigInteger;
-import java.util.*;
-import java.util.function.BiConsumer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/spark-job/src/main/java/org/apache/cassandra/diff/Differ.java
+++ b/spark-job/src/main/java/org/apache/cassandra/diff/Differ.java
@@ -23,24 +23,25 @@ import java.io.PrintWriter;
 import java.io.Serializable;
 import java.io.StringWriter;
 import java.math.BigInteger;
-import java.util.*;
-import java.util.function.BiFunction;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.function.BiConsumer;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Verify;
-import com.google.common.util.concurrent.*;
-
+import com.google.common.util.concurrent.RateLimiter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.datastax.driver.core.ConsistencyLevel;
-import com.datastax.driver.core.Session;
-
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.Session;
 
 public class Differ implements Serializable
 {

--- a/spark-job/src/main/java/org/apache/cassandra/diff/PartitionComparator.java
+++ b/spark-job/src/main/java/org/apache/cassandra/diff/PartitionComparator.java
@@ -20,12 +20,13 @@
 package org.apache.cassandra.diff;
 
 import java.util.Iterator;
-import java.util.concurrent.*;
+import java.util.concurrent.Callable;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.datastax.driver.core.*;
+import com.datastax.driver.core.ColumnMetadata;
+import com.datastax.driver.core.Row;
 
 public class PartitionComparator implements Callable<PartitionStats> {
 

--- a/spark-job/src/main/java/org/apache/cassandra/diff/PartitionKey.java
+++ b/spark-job/src/main/java/org/apache/cassandra/diff/PartitionKey.java
@@ -28,7 +28,10 @@ import java.util.stream.StreamSupport;
 
 import com.google.common.annotations.VisibleForTesting;
 
-import com.datastax.driver.core.*;
+import com.datastax.driver.core.ColumnDefinitions;
+import com.datastax.driver.core.DataType;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Token;
 import org.jetbrains.annotations.NotNull;
 
 public class PartitionKey implements Comparable<PartitionKey> {

--- a/spark-job/src/main/java/org/apache/cassandra/diff/RangeComparator.java
+++ b/spark-job/src/main/java/org/apache/cassandra/diff/RangeComparator.java
@@ -20,11 +20,13 @@
 package org.apache.cassandra.diff;
 
 import java.math.BigInteger;
-import java.util.*;
-import java.util.concurrent.*;
+import java.util.Iterator;
+import java.util.concurrent.Phaser;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.*;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 import com.google.common.base.Verify;
 import org.slf4j.Logger;

--- a/spark-job/src/main/java/org/apache/cassandra/diff/RangeStats.java
+++ b/spark-job/src/main/java/org/apache/cassandra/diff/RangeStats.java
@@ -19,7 +19,10 @@
 
 package org.apache.cassandra.diff;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.util.Objects;
 import java.util.concurrent.atomic.LongAdder;
 

--- a/spark-job/src/main/java/org/apache/cassandra/diff/TableSpec.java
+++ b/spark-job/src/main/java/org/apache/cassandra/diff/TableSpec.java
@@ -30,14 +30,14 @@ import static org.apache.cassandra.diff.DiffContext.cqlizedString;
 
 public class TableSpec {
 
-    private final String table;
+    private final KeyspaceTablePair keyspaceTablePair;
     private ImmutableList<ColumnMetadata> clusteringColumns;
     private ImmutableList<ColumnMetadata> regularColumns;
 
 
-    public String getTable()
+    public KeyspaceTablePair getTable()
     {
-        return table;
+        return keyspaceTablePair;
     }
 
 
@@ -55,23 +55,23 @@ public class TableSpec {
      * @param clusteringColumns the clustering columns, retrieved from cluster using the client
      * @param regularColumns the non-primary key columns, retrieved from cluster using the client
      */
-    TableSpec(final String table,
+    TableSpec(final KeyspaceTablePair table,
               final List<ColumnMetadata> clusteringColumns,
               final List<ColumnMetadata> regularColumns) {
-        this.table = table;
+        this.keyspaceTablePair = table;
         this.clusteringColumns = ImmutableList.copyOf(clusteringColumns);
         this.regularColumns = ImmutableList.copyOf(regularColumns);
     }
 
-    public static TableSpec make(String table, DiffCluster diffCluster) {
+    public static TableSpec make(KeyspaceTablePair keyspaceTablePair, DiffCluster diffCluster) {
         final Cluster cluster = diffCluster.cluster;
 
-        final String cqlizedKeyspace = cqlizedString(diffCluster.keyspace);
-        final String cqlizedTable = cqlizedString(table);
+        final String cqlizedKeyspace = cqlizedString(keyspaceTablePair.keyspace);
+        final String cqlizedTable = cqlizedString(keyspaceTablePair.table);
 
         KeyspaceMetadata ksMetadata = cluster.getMetadata().getKeyspace(cqlizedKeyspace);
         if (ksMetadata == null) {
-            throw new IllegalArgumentException(String.format("Keyspace %s not found in %s cluster", diffCluster.keyspace, diffCluster.clusterId));
+            throw new IllegalArgumentException(String.format("Keyspace %s not found in %s cluster", keyspaceTablePair.keyspace, diffCluster.clusterId));
         }
 
         TableMetadata tableMetadata = ksMetadata.getTable(cqlizedTable);
@@ -80,11 +80,11 @@ public class TableSpec {
                                                            .stream()
                                                            .filter(c -> !(clusteringColumns.contains(c)))
                                                            .collect(Collectors.toList());
-        return new TableSpec(tableMetadata.getName(), clusteringColumns, regularColumns);
+        return new TableSpec(KeyspaceTablePair.from(tableMetadata), clusteringColumns, regularColumns);
     }
 
     public boolean equalsNamesOnly(TableSpec other) {
-        return this.table.equals(other.table)
+        return this.keyspaceTablePair.equals(other.keyspaceTablePair)
             && columnNames(this.clusteringColumns).equals(columnNames(other.clusteringColumns))
             && columnNames(this.regularColumns).equals(columnNames(other.regularColumns));
     }
@@ -101,19 +101,19 @@ public class TableSpec {
             return false;
 
         TableSpec other = (TableSpec)o;
-        return this.table.equals(other.table)
+        return this.keyspaceTablePair.equals(other.keyspaceTablePair)
                && this.clusteringColumns.equals(other.clusteringColumns)
                && this.regularColumns.equals(other.regularColumns);
 
     }
 
     public int hashCode() {
-        return Objects.hash(table, clusteringColumns, regularColumns);
+        return Objects.hash(keyspaceTablePair, clusteringColumns, regularColumns);
     }
 
     public String toString() {
         return MoreObjects.toStringHelper(this)
-                          .add("table", table)
+                          .add("table", keyspaceTablePair)
                           .add("clusteringColumns", clusteringColumns)
                           .add("regularColumns", regularColumns)
                           .toString();

--- a/spark-job/src/main/java/org/apache/cassandra/diff/TableSpec.java
+++ b/spark-job/src/main/java/org/apache/cassandra/diff/TableSpec.java
@@ -19,12 +19,17 @@
 
 package org.apache.cassandra.diff;
 
-import com.datastax.driver.core.*;
-import java.util.*;
+import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.ColumnMetadata;
+import com.datastax.driver.core.KeyspaceMetadata;
+import com.datastax.driver.core.TableMetadata;
 
 import static org.apache.cassandra.diff.DiffContext.cqlizedString;
 

--- a/spark-job/src/test/java/org/apache/cassandra/diff/DiffJobTest.java
+++ b/spark-job/src/test/java/org/apache/cassandra/diff/DiffJobTest.java
@@ -24,9 +24,6 @@ import java.util.List;
 
 import org.junit.Test;
 
-import org.apache.cassandra.diff.DiffJob;
-import org.apache.cassandra.diff.TokenHelper;
-
 import static org.junit.Assert.assertEquals;
 
 public class DiffJobTest

--- a/spark-job/src/test/java/org/apache/cassandra/diff/DifferTest.java
+++ b/spark-job/src/test/java/org/apache/cassandra/diff/DifferTest.java
@@ -22,17 +22,10 @@ package org.apache.cassandra.diff;
 import java.math.BigInteger;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import com.google.common.base.VerifyException;
-import org.junit.Test;
-
 import com.google.common.collect.Lists;
-
-import org.apache.cassandra.diff.DiffJob;
-import org.apache.cassandra.diff.Differ;
-import org.apache.cassandra.diff.RangeStats;
-import org.apache.cassandra.diff.TokenHelper;
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -75,7 +68,6 @@ public class DifferTest {
         // * t2 is started and has reported some progress, but has not completed
         // * t3 has not reported any progress
         DiffJob.Split split = new DiffJob.Split(1, 1, BigInteger.ONE, BigInteger.TEN);
-        //todo
         Iterable<KeyspaceTablePair> tables = Lists.newArrayList(ksTbl("t1"), ksTbl("t2"), ksTbl("t3"));
         Function<KeyspaceTablePair, DiffJob.TaskStatus> journal = (keyspaceTable) -> {
             switch (keyspaceTable.table) {

--- a/spark-job/src/test/java/org/apache/cassandra/diff/DifferTest.java
+++ b/spark-job/src/test/java/org/apache/cassandra/diff/DifferTest.java
@@ -22,6 +22,7 @@ package org.apache.cassandra.diff;
 import java.math.BigInteger;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import com.google.common.base.VerifyException;
 import org.junit.Test;
@@ -74,9 +75,10 @@ public class DifferTest {
         // * t2 is started and has reported some progress, but has not completed
         // * t3 has not reported any progress
         DiffJob.Split split = new DiffJob.Split(1, 1, BigInteger.ONE, BigInteger.TEN);
-        Iterable<String> tables = Lists.newArrayList("t1", "t2", "t3");
-        Function<String, DiffJob.TaskStatus> journal = (table) -> {
-            switch (table) {
+        //todo
+        Iterable<KeyspaceTablePair> tables = Lists.newArrayList(ksTbl("t1"), ksTbl("t2"), ksTbl("t3"));
+        Function<KeyspaceTablePair, DiffJob.TaskStatus> journal = (keyspaceTable) -> {
+            switch (keyspaceTable.table) {
                 case "t1":
                     return new DiffJob.TaskStatus(split.end, RangeStats.withValues(6, 6, 6, 6, 6, 6, 6, 6, 6));
                 case "t2":
@@ -88,24 +90,27 @@ public class DifferTest {
             }
         };
 
-        Map<String, DiffJob.TaskStatus> filtered = Differ.filterTables(tables, split, journal, false);
+        Map<KeyspaceTablePair, DiffJob.TaskStatus> filtered = Differ.filterTables(tables, split, journal, false);
         assertEquals(2, filtered.keySet().size());
-        assertEquals(RangeStats.withValues(5, 5, 5, 5, 5, 5, 5, 5, 5), filtered.get("t2").stats);
-        assertEquals(BigInteger.valueOf(5L), filtered.get("t2").lastToken);
-        assertEquals(RangeStats.newStats(), filtered.get("t3").stats);
-        assertNull(filtered.get("t3").lastToken);
+        assertEquals(RangeStats.withValues(5, 5, 5, 5, 5, 5, 5, 5, 5), filtered.get(ksTbl("t2")).stats);
+        assertEquals(BigInteger.valueOf(5L), filtered.get(ksTbl("t2")).lastToken);
+        assertEquals(RangeStats.newStats(), filtered.get(ksTbl("t3")).stats);
+        assertNull(filtered.get(ksTbl("t3")).lastToken);
 
         // if re-running (part of) a job because of failures or problematic partitions, we want to
         // ignore the status of completed tasks and re-run them anyway as only specified tokens will
         // be processed - so t1 should be included now
         filtered = Differ.filterTables(tables, split, journal, true);
         assertEquals(3, filtered.keySet().size());
-        assertEquals(RangeStats.withValues(6, 6, 6, 6, 6, 6, 6, 6, 6), filtered.get("t1").stats);
-        assertEquals(split.end, filtered.get("t1").lastToken);
-        assertEquals(RangeStats.withValues(5, 5, 5, 5, 5, 5, 5, 5, 5), filtered.get("t2").stats);
-        assertEquals(BigInteger.valueOf(5L), filtered.get("t2").lastToken);
-        assertEquals(RangeStats.newStats(), filtered.get("t3").stats);
-        assertNull(filtered.get("t3").lastToken);
+        assertEquals(RangeStats.withValues(6, 6, 6, 6, 6, 6, 6, 6, 6), filtered.get(ksTbl("t1")).stats);
+        assertEquals(split.end, filtered.get(ksTbl("t1")).lastToken);
+        assertEquals(RangeStats.withValues(5, 5, 5, 5, 5, 5, 5, 5, 5), filtered.get(ksTbl("t2")).stats);
+        assertEquals(BigInteger.valueOf(5L), filtered.get(ksTbl("t2")).lastToken);
+        assertEquals(RangeStats.newStats(), filtered.get(ksTbl("t3")).stats);
+        assertNull(filtered.get(ksTbl("t3")).lastToken);
     }
 
+    private KeyspaceTablePair ksTbl(String table) {
+        return new KeyspaceTablePair("ks", table);
+    }
 }

--- a/spark-job/src/test/java/org/apache/cassandra/diff/PartitionComparatorTest.java
+++ b/spark-job/src/test/java/org/apache/cassandra/diff/PartitionComparatorTest.java
@@ -33,9 +33,6 @@ import com.google.common.reflect.TypeToken;
 import org.junit.Test;
 
 import com.datastax.driver.core.*;
-import org.apache.cassandra.diff.PartitionComparator;
-import org.apache.cassandra.diff.PartitionStats;
-import org.apache.cassandra.diff.TableSpec;
 
 import static org.junit.Assert.assertEquals;
 

--- a/spark-job/src/test/java/org/apache/cassandra/diff/PartitionComparatorTest.java
+++ b/spark-job/src/test/java/org/apache/cassandra/diff/PartitionComparatorTest.java
@@ -221,7 +221,7 @@ public class PartitionComparatorTest {
     }
 
     TableSpec spec(String table, List<String> clusteringColumns, List<String> regularColumns) {
-        return new TableSpec(table, columns(clusteringColumns), columns(regularColumns));
+        return new TableSpec(new KeyspaceTablePair("ks", table), columns(clusteringColumns), columns(regularColumns));
     }
 
     List<ColumnMetadata> columns(List<String> names) {


### PR DESCRIPTION
- Replaced discrete inputs, keyspace and tables, with one list of keyspace table pairs. Now a table is identified by keyspace and table name.
- The scheme of JobMetadataDb is updated correspondingly to replace all 'table_name' with 'keyspace_table_name' and replace `table_names` with `keyspace_table_names`
- DBService in api service is changed to make sure it can query with the new schema.
- Readme is updated to include an example of running with multiple keyspaces.