### PR TITLE
Fix transitive dependency on a SNAPSHOT version of commons-codec.

### DIFF
--- a/spark-job/pom.xml
+++ b/spark-job/pom.xml
@@ -61,6 +61,13 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.14</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- test dependencies -->
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Building the master branch from scratch throws the following exception:

`[ERROR] Failed to execute goal on project spark-job: Could not resolve dependencies for project org.apache.cassandra.diff:spark-job:jar:0.2-SNAPSHOT: Could not find artifact commons-codec:commons-codec:jar:1.15-SNAPSHOT`

There's a transitive dependency on a SNAPSHOT version of commons-codec and the corresponding release (1.15) is not available yet in Maven Central.
The dependency tree looks like this:

```
org.apache.spark:spark-core_2.11:jar:2.3.3:provided
	net.java.dev.jets3t:jets3t:jar:0.9.4:provided
		commons-codec:commons-codec:jar:1.15-SNAPSHOT:provided
```

We can fix the build by explicitly declaring a dependency on the latest release version (1.14) with a PROVIDED scope too, which makes the build work and it will rely on whatever version is available at runtime.