### PR TITLE
CASSANDRA-16065: Distinguish partition error source cluster

### DIFF
--- a/spark-job/src/main/java/org/apache/cassandra/diff/ClusterSourcedException.java
+++ b/spark-job/src/main/java/org/apache/cassandra/diff/ClusterSourcedException.java
@@ -1,0 +1,31 @@
+package org.apache.cassandra.diff;
+
+import java.util.concurrent.Callable;
+
+import org.apache.cassandra.diff.DiffCluster.Type;
+
+/**
+ * Wraps the cause with the exception source indicator, {@param type} of the cluster.
+ * It is used to distinguish driver exceptions among testing clusters.
+ */
+public class ClusterSourcedException extends RuntimeException {
+    public final Type exceptionSource;
+
+    ClusterSourcedException(Type exceptionSource, Throwable cause) {
+        super(cause);
+        this.exceptionSource = exceptionSource;
+    }
+
+    public static <T> T catches(Type exceptionSource, Callable<T> callable) {
+        try {
+            return callable.call();
+        } catch (Exception ex) {
+            throw new ClusterSourcedException(exceptionSource, ex);
+        }
+    }
+
+    @Override
+    public String getMessage() {
+        return String.format("from %s - %s", exceptionSource.name(), super.getMessage());
+    }
+}

--- a/spark-job/src/main/java/org/apache/cassandra/diff/RangeComparator.java
+++ b/spark-job/src/main/java/org/apache/cassandra/diff/RangeComparator.java
@@ -125,8 +125,7 @@ public class RangeComparator {
                         // unavailables occurring when performing the initial query to read the full partition.
                         // Errors thrown when paging through the partition in comparisonTask will be handled by
                         // the onError callback.
-                        rangeStats.partitionError();
-                        errorReporter.accept(t, token);
+                        recordError(rangeStats, token, errorReporter, t);
                     } finally {
                         // if the cluster has been shutdown because the task failed the underlying iterators
                         // of partition keys will return hasNext == false
@@ -224,10 +223,15 @@ public class RangeComparator {
     private Consumer<Throwable> onError(final RangeStats rangeStats,
                                         final BigInteger currentToken,
                                         final BiConsumer<Throwable, BigInteger> errorReporter) {
-        return (error) -> {
-            rangeStats.partitionError();
-            errorReporter.accept(error, currentToken);
-        };
+        return (error) -> recordError(rangeStats, currentToken, errorReporter, error);
+    }
+
+    private void recordError(final RangeStats rangeStats,
+                             final BigInteger currentToken,
+                             final BiConsumer<Throwable, BigInteger> errorReporter,
+                             final Throwable error) {
+        rangeStats.partitionError();
+        errorReporter.accept(error, currentToken);
     }
 }
 

--- a/spark-job/src/test/java/org/apache/cassandra/diff/ClusterSourcedExceptionTest.java
+++ b/spark-job/src/test/java/org/apache/cassandra/diff/ClusterSourcedExceptionTest.java
@@ -1,0 +1,33 @@
+package org.apache.cassandra.diff;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.CustomMatcher;
+
+public class ClusterSourcedExceptionTest {
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testCatchesExceptionHasExceptionSourceInfo() {
+        expectedException.expect(ClusterSourcedException.class);
+        expectedException.expectCause(CoreMatchers.isA(RuntimeException.class));
+        expectedException.expectMessage("from SOURCE");
+        expectedException.expect(new CustomMatcher<ClusterSourcedException>("matches the expected exceptionSource: SOURCE") {
+            @Override
+            public boolean matches(Object item) {
+                if (item instanceof ClusterSourcedException) {
+                    ClusterSourcedException ex = (ClusterSourcedException) item;
+                    return ex.exceptionSource == DiffCluster.Type.SOURCE;
+                }
+                return false;
+            }
+        });
+        ClusterSourcedException.catches(DiffCluster.Type.SOURCE, () -> {
+            throw new RuntimeException();
+        });
+    }
+}


### PR DESCRIPTION
- Wraps client error with ClusterSourcedException to distinguish the error source.
- Stores `error_source text` in the error details table in metadata.