### PR TITLE
Cassandra diff should accept a provided job_id for retrying diffs

### DIFF
--- a/spark-job/pom.xml
+++ b/spark-job/pom.xml
@@ -67,5 +67,12 @@
             <artifactId>junit</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.5.10</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 </project>

--- a/spark-job/src/main/java/org/apache/cassandra/diff/JobMetadataDb.java
+++ b/spark-job/src/main/java/org/apache/cassandra/diff/JobMetadataDb.java
@@ -369,7 +369,7 @@ public class JobMetadataDb {
                                                          metadataKeyspace, Schema.RUNNING_JOBS),
                                            params.jobId);
             if (!rs.one().getBool("[applied]")) {
-                logger.info("Aborting due to inability to mark job as running. " +
+                logger.info("Could not mark job as running. " +
                             "Did a previous run of job id {} fail non-gracefully?",
                             params.jobId);
                 throw new RuntimeException("Unable to mark job running, aborting");


### PR DESCRIPTION
This Pull Request fixes two bugs that surfaced during retrying diff jobs with same JobId.

1. The try resource block in DiffJob.java closes the session object before the code in exception or finally block gets executed. We are marking the job as not running in the exception block which throws an exception as the session object is already closed. Chaning the resource try catch block to try catch finally block so that session object will not be closed until cleanup is complete.
2. When job_id is passed as a config property for the first time, we will not have metadata associated with job_id in metadata table but the current code attempts to get the job metadata for the passed jobId and as those details will not be present, a null pointer exception is thrown. This Pr fixes this issue by getting jobParameters from the table only when they are available otherwise creates new job parameters with passed JobId or random UUID.